### PR TITLE
Datalogging fix

### DIFF
--- a/v93k/src/origen/origen/test_method/dc_measurement.cpp
+++ b/v93k/src/origen/origen/test_method/dc_measurement.cpp
@@ -41,6 +41,8 @@ void DCMeasurement::execute() {
 
     RDI_INIT();
 
+    pin(extractPinsFromGroup(_pin));
+	
     ON_FIRST_INVOCATION_BEGIN();
 
         enableHiddenUpload();
@@ -52,7 +54,7 @@ void DCMeasurement::execute() {
         GET_TESTSUITE_NAME(testSuiteName);
         label = Primary.getLabel();
 
-        pin(extractPinsFromGroup(_pin));
+        
 
         if (_applyShutdown) {
             if (_shutdownPattern.empty()) {


### PR DESCRIPTION
When you call extractPinsFromGroup from within the first invocation block it will only be called for the first site. This is fine for the measurements since they happen in the first invocation block, but the processing (judgeAndLog_ParametricTest), also uses _pin. Here it will have the group name for the subsequent pins since you call the .pin(GROUPNAME); function from outside the first_invocation_block from the main testsuite, so it will be called multiple times, once for each site, while you process the groupname only once. Solution is to either call the .pin(GROUPNAME) function from inside a first invocation block as well, or process the groupname outside the first invocation block as I have done here.